### PR TITLE
can now run generate project from the view project

### DIFF
--- a/src/main/java/plugin/Generator.java
+++ b/src/main/java/plugin/Generator.java
@@ -1,0 +1,22 @@
+package plugin;
+
+import com.intellij.openapi.actionSystem.AnAction;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import plugin.action.ActionGenerator;
+
+/**
+ * Created by Benjamin DANGLOT
+ * benjamin.danglot@inria.fr
+ * on 12/7/16
+ */
+public class Generator extends AnAction {
+
+    public Generator() {
+        super("Generate toy-project");
+    }
+
+    @Override
+    public void actionPerformed(AnActionEvent e) {
+        new ActionGenerator(e.getProject()).actionPerformed(null);
+    }
+}

--- a/src/main/java/plugin/Plugin.java
+++ b/src/main/java/plugin/Plugin.java
@@ -29,8 +29,13 @@ public class Plugin extends AnAction {
 
     public Plugin() {
         super("NoPol");
-        ActorManager.createActorSystem(getClass().getClassLoader());
+        ActorManager.createActorSystem(Plugin.class.getClassLoader());
         ProjectManager.getInstance().addProjectManagerListener(new ProjectManagerAdapter() {
+            @Override
+            public void projectOpened(Project project) {
+                ActorManager.launchNopol();
+            }
+
             @Override
             public void projectClosed(Project project) {
                 ActorManager.stopNopolLocally();
@@ -42,11 +47,10 @@ public class Plugin extends AnAction {
             throw new RuntimeException(e);
         }
         initConfig();
-        ActorManager.launchNopol();
         EventSender.send(EventSender.Event.START_PLUGIN);
     }
 
-    private void initConfig() {
+    private static void initConfig() {
         config.setSynthesis(Config.NopolSynthesis.DYNAMOTH);
         config.setType(StatementType.PRE_THEN_COND);
 //        config.setLocalizer(Config.NopolLocalizer.OCHIAI); //CoCospoon take too much time

--- a/src/main/java/plugin/actors/ActorManager.java
+++ b/src/main/java/plugin/actors/ActorManager.java
@@ -45,6 +45,7 @@ public class ActorManager {
             remoteActor = system.actorFor("akka.tcp://NopolActorSystem@127.0.0.1:2553/user/NopolActor");
         } catch (Exception ignored) {
             nopolIsRunning = false;
+            throw new RuntimeException(ignored);
             //should give to the client the reason that we could not run nopol locally
         }
     }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -52,8 +52,14 @@
     <actions>
         <group id="nopol-plugin.NoPolMenu" text="Nopol" description="Nopol menu">
             <add-to-group group-id="EditorPopupMenu" anchor="first"/>
-            <action class="plugin.Plugin" id="nopol-plugin.Plugin"
+            <action class="plugin.Plugin" id="nopol-plugin.PluginEditor"
                     text="Nopol" description="Configure and run Nopol">
+            </action>
+        </group>
+        <group id="nopol-plugin.GeneratorMenu" text="Generate toy-project" description="Generate toy project">
+            <add-to-group group-id="ProjectViewPopupMenu" anchor="first"/>
+            <action class="plugin.Generator" id="nopol-plugin.GeneratorProjectView"
+                    text="Generate toy-project" description="Generate a toy-project to try the plugin">
             </action>
         </group>
     </actions>


### PR DESCRIPTION
I build a new AnAction, specificity for the case where we want to generate a toy-project without any classes, because of the static context of ActorManager (build in Plugin, which is instantiate twice if we add it to the ProjectViewPopupMenu)